### PR TITLE
Support ansible-container

### DIFF
--- a/tasks/cleanup.yml
+++ b/tasks/cleanup.yml
@@ -1,0 +1,9 @@
+---
+
+- name: Clean yum cache
+  command: yum clean all
+  when: ansible_os_family == 'RedHat'
+
+- name: Clean apt cache
+  command: apt-get clean
+  when: ansible_os_family == 'Debian'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,3 +21,7 @@
   package:
     name: sbt
     state: latest
+
+- name: Cleanup package caches if building a container
+  include: cleanup.yml
+  when: ansible_env.ANSIBLE_CONTAINER is defined

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,6 +6,10 @@
 # sudo apt-get update
 # sudo apt-get install sbt
 
+- name: Determine whether to use sudo for package installations
+  set_fact:
+    should_become: "{{ ansible_env.ANSIBLE_CONTAINER is not defined }}"
+
 - include: setup-Debian.yml
   when: ansible_os_family == 'Debian'
 
@@ -13,7 +17,7 @@
   when: ansible_os_family == 'RedHat'
 
 - name: 'Install SBT package'
-  become: yes
+  become: "{{ should_become }}"
   package:
     name: sbt
     state: latest

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -8,13 +8,13 @@
     - ca-certificates
     
 - name: 'Adding APT key'
-  become: yes
+  become: "{{ should_become }}"
   apt_key:
     keyserver: hkp://keyserver.ubuntu.com:80
     id: 642AC823
 
 - name: 'Adding APT repository'
-  become: yes
+  become: "{{ should_become }}"
   apt_repository:
     repo: deb https://dl.bintray.com/sbt/debian /
     state: present

--- a/tasks/setup-Debian.yml
+++ b/tasks/setup-Debian.yml
@@ -3,6 +3,7 @@
   package:
     name: "{{ item }}"
     state: present
+    update_cache: "{{ ansible_env.ANSIBLE_CONTAINER is defined | bool }}"
   with_items:
     - apt-transport-https
     - ca-certificates

--- a/tasks/setup-RedHat.yml
+++ b/tasks/setup-RedHat.yml
@@ -1,6 +1,6 @@
 ---
 - name: 'Adding YUM repository'
-  become: yes
+  become: "{{ should_become }}"
   get_url:
     url: https://bintray.com/sbt/rpm/rpm
     dest: /etc/yum.repos.d/bintray-sbt-rpm.repo


### PR DESCRIPTION
@deiga 

Great role! I've been using it to build Play apps in-place on VMs. 

Recently I started using ansible-container to build Docker images, and this role has some minor compatibility issues:
* sudo is not recommended inside containers, so all `become` tags are now conditional on whether ansible-container is being used to run the role
* Usually base container images don't have an apt/yum cache, so I added update_cache to the initial dependency install
* To keep image sizes down, if ansible-container is being used the apt/yum cache will be flushed

Hope you'll accept these minor changes, if you're not using ansible-container they should not have any effect whatsoever!